### PR TITLE
feat: added Multi AUs support for iframe

### DIFF
--- a/openedx_cmi5_xblock/static/html/openedx_cmi5_xblock.html
+++ b/openedx_cmi5_xblock/static/html/openedx_cmi5_xblock.html
@@ -2,11 +2,26 @@
 
 <div class="openedx_cmi5_xblock_block">
     <h3 class="xblock-title mb-2">{{title}}</h3>
+    <br>
+    
     {% if index_page_url %}
+    <h5 class="xblock-title mb-2"> {% trans "Available Assignables:" %}</h5>
+    <ol>
+        {% for au_url in au_urls %}
+                <li>
+                    <a href="{{ au_url.url }}" target="_blank">
+                        <span>{% trans "AU No." %}</span> {{ forloop.counter }}
+                    </a>
+                    ({%trans "Launch: "%} {{au_url.launch_method}})
+                </li>
+            
+        {% endfor %}
+    </ol>
+
     <div class="cmi5-content">
         <iframe
             class="cmi5-embedded"
-            src="{{ index_page_url }}"
+            src=""
             width="{% if cmi5_xblock.width %}{{ cmi5_xblock.width }}%{% else %}100%{% endif %}"
             height="{% if cmi5_xblock.height %}{{ cmi5_xblock.height }}{% else %}450{% endif %}"
         >

--- a/openedx_cmi5_xblock/static/js/src/openedx_cmi5_xblock.js
+++ b/openedx_cmi5_xblock/static/js/src/openedx_cmi5_xblock.js
@@ -1,14 +1,29 @@
 /* Javascript for CMI5XBlock. */
 function CMI5XBlock(runtime, element) {
 
+  $(function($) {
+      /*
+      Use `gettext` provided by django-statici18n for static translations
 
-  $(function ($) {
-    /*
-    Use `gettext` provided by django-statici18n for static translations
+      var gettext = CMI5XBlocki18n.gettext;
+      */
 
-    var gettext = CMI5XBlocki18n.gettext;
-    */
+      /* Here's where you'd do things on page load. */
 
-    /* Here's where you'd do things on page load. */
+      $('ol a').click(function(event) {
+          event.preventDefault();
+          var href = $(this).attr('href');
+          var liText = $(this).closest('li').text().trim();
+          updateIframeSrc(href, liText);
+
+      });
+
+      function updateIframeSrc(href, liText) {
+          if (liText.includes('AnyWindow')) {
+              $('.cmi5-embedded').attr('src', href);
+          } else if (liText.includes('OwnWindow')) {
+              window.open(href, '_blank');
+          }
+      }
   });
 }


### PR DESCRIPTION
Added support for cmi5 content having multiple AUs.
AUs with different launch methods ('OwnWindow', 'AnyWindow') are displayed differently.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
