### PR TITLE
fix: no module named importlib_resources

### DIFF
--- a/openedx_cmi5_xblock/__init__.py
+++ b/openedx_cmi5_xblock/__init__.py
@@ -2,4 +2,4 @@
 
 from .openedx_cmi5_xblock import CMI5XBlock
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/openedx_cmi5_xblock/openedx_cmi5_xblock.py
+++ b/openedx_cmi5_xblock/openedx_cmi5_xblock.py
@@ -661,7 +661,6 @@ def resource_string(path):
         data = importlib_resources.files(__name__).joinpath(path).read_bytes()
     except TypeError:
         data = importlib_resources.files(__package__).joinpath(path).read_bytes()
-    return data.decode("utf8")
     return data.decode('utf8')
 
 

--- a/openedx_cmi5_xblock/openedx_cmi5_xblock.py
+++ b/openedx_cmi5_xblock/openedx_cmi5_xblock.py
@@ -10,7 +10,6 @@ import uuid
 import xml.etree.ElementTree as ET
 import zipfile
 
-import importlib_resources
 import requests
 from django.conf import settings
 from django.core.files.base import ContentFile
@@ -36,6 +35,16 @@ from openedx_cmi5_xblock.utils.utility import (
     parse_int,
     send_xapi_to_external_lrs,
 )
+
+try:
+    # Older Open edX releases (Redwood and earlier) install a backported version of
+    # importlib.resources: https://pypi.org/project/importlib-resources/
+    import importlib_resources
+except ModuleNotFoundError:
+    # Starting with Sumac, Open edX drops importlib-resources in favor of the standard library:
+    # https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources
+    from importlib import resources as importlib_resources
+
 
 logger = logging.getLogger(__name__)
 
@@ -648,7 +657,11 @@ class CMI5XBlock(XBlock, CompletableXBlockMixin):
 
 def resource_string(path):
     """Handy helper for getting resources from our kit."""
-    data = importlib_resources.files(__name__).joinpath(path).read_bytes()
+    try:
+        data = importlib_resources.files(__name__).joinpath(path).read_bytes()
+    except TypeError:
+        data = importlib_resources.files(__package__).joinpath(path).read_bytes()
+    return data.decode("utf8")
     return data.decode('utf8')
 
 


### PR DESCRIPTION
The Open edX CMI5 XBlock utilizes importlib_resources for file imports. This XBlock was developed during the Quince release, benefiting from the fact that the edx-platform included importlib_resources in both the Quince and Redwood versions. As a result, the XBlock functioned seamlessly across both releases.

However, with the recent removal of importlib_resources from the edx-platform, the XBlock now encounters errors related to Sumac. This pull request addresses and resolves the issue.

Additional context can be found https://github.com/overhangio/openedx-scorm-xblock/pull/80#issue-2372890086.